### PR TITLE
Fixed plugin help extracted from documentation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -651,7 +651,7 @@
           <dependency>
             <groupId>com.github.gantsign.maven.plugin-tools</groupId>
             <artifactId>kotlin-maven-plugin-tools</artifactId>
-            <version>0.9.2</version>
+            <version>0.9.3</version>
           </dependency>
         </dependencies>
         <executions>


### PR DESCRIPTION
It was truncating at the first '('.