### PR TITLE
Renamed LintBase to AbstractLintSupport

### DIFF
--- a/src/main/kotlin/com/github/gantsign/maven/plugin/ktlint/internal/AbstractLintSupport.kt
+++ b/src/main/kotlin/com/github/gantsign/maven/plugin/ktlint/internal/AbstractLintSupport.kt
@@ -27,7 +27,7 @@ import java.io.File
 import java.util.Comparator.comparingInt
 import java.util.ServiceLoader
 
-internal abstract class LintBase(
+internal abstract class AbstractLintSupport(
     protected val log: Log,
     protected val basedir: File,
     private val android: Boolean

--- a/src/main/kotlin/com/github/gantsign/maven/plugin/ktlint/internal/Check.kt
+++ b/src/main/kotlin/com/github/gantsign/maven/plugin/ktlint/internal/Check.kt
@@ -47,7 +47,7 @@ internal class Check(
     private val reporterConfig: Set<ReporterConfig>,
     private val verbose: Boolean,
     private val failOnViolation: Boolean
-) : LintBase(log, basedir, android) {
+) : AbstractLintSupport(log, basedir, android) {
 
     private val reporter: Reporter by lazy {
         data class ReporterTemplate(

--- a/src/main/kotlin/com/github/gantsign/maven/plugin/ktlint/internal/Format.kt
+++ b/src/main/kotlin/com/github/gantsign/maven/plugin/ktlint/internal/Format.kt
@@ -36,7 +36,7 @@ internal class Format(
     private val includes: Set<String>,
     private val excludes: Set<String>,
     android: Boolean
-) : LintBase(log, basedir, android) {
+) : AbstractLintSupport(log, basedir, android) {
 
     operator fun invoke() {
 


### PR DESCRIPTION
For naming consistency with other abstract classes.