### PR TITLE
Updated HttpClient to 4.5.5

### DIFF
--- a/ktlint-maven-plugin.iml
+++ b/ktlint-maven-plugin.iml
@@ -35,10 +35,10 @@
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="Maven: com.github.gantsign.maven.doxia:doxia-sink-api-ktx:0.5.7" level="project" />
     <orderEntry type="library" name="Maven: org.apache.maven.doxia:doxia-core:1.8" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.httpcomponents:httpclient:4.0.2" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.httpcomponents:httpclient:4.5.5" level="project" />
     <orderEntry type="library" name="Maven: commons-logging:commons-logging:1.2" level="project" />
-    <orderEntry type="library" name="Maven: commons-codec:commons-codec:1.3" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.httpcomponents:httpcore:4.0.1" level="project" />
+    <orderEntry type="library" name="Maven: commons-codec:commons-codec:1.10" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.httpcomponents:httpcore:4.4.9" level="project" />
     <orderEntry type="library" name="Maven: com.github.shyiko:ktlint:0.23.1" level="project" />
     <orderEntry type="library" name="Maven: org.jetbrains.kotlin:kotlin-stdlib:1.2.41" level="project" />
     <orderEntry type="library" name="Maven: com.github.shyiko.ktlint:ktlint-ruleset-standard:0.23.1" level="project" />

--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,16 @@
         <version>3.7</version>
       </dependency>
       <dependency>
+        <groupId>org.apache.httpcomponents</groupId>
+        <artifactId>httpclient</artifactId>
+        <version>4.5.5</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.httpcomponents</groupId>
+        <artifactId>httpcore</artifactId>
+        <version>4.4.9</version>
+      </dependency>
+      <dependency>
         <groupId>org.apache.maven</groupId>
         <artifactId>maven-artifact</artifactId>
         <version>${maven.version}</version>


### PR DESCRIPTION
Fixes for the following vulnerabilities:
* https://snyk.io/vuln/SNYK-JAVA-ORGAPACHEHTTPCOMPONENTS-30647
* https://snyk.io/vuln/SNYK-JAVA-ORGAPACHEHTTPCOMPONENTS-31517
* https://snyk.io/vuln/SNYK-JAVA-ORGAPACHEHTTPCOMPONENTS-30645
* https://snyk.io/vuln/SNYK-JAVA-ORGAPACHEHTTPCOMPONENTS-30644
* https://snyk.io/vuln/SNYK-JAVA-ORGAPACHEHTTPCOMPONENTS-30646