### PR TITLE
Excluded transitive Apache Struts dependency

### DIFF
--- a/ktlint-maven-plugin.iml
+++ b/ktlint-maven-plugin.iml
@@ -85,10 +85,6 @@
     <orderEntry type="library" name="Maven: dom4j:dom4j:1.1" level="project" />
     <orderEntry type="library" name="Maven: oro:oro:2.0.8" level="project" />
     <orderEntry type="library" name="Maven: sslext:sslext:1.2-0" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.struts:struts-core:1.3.8" level="project" />
-    <orderEntry type="library" name="Maven: antlr:antlr:2.7.2" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.struts:struts-taglib:1.3.8" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.struts:struts-tiles:1.3.8" level="project" />
     <orderEntry type="library" name="Maven: commons-collections:commons-collections:3.2.2" level="project" />
     <orderEntry type="library" name="Maven: commons-lang:commons-lang:2.4" level="project" />
     <orderEntry type="library" name="Maven: org.apache.maven.shared:maven-shared-utils:3.2.1" level="project" />

--- a/pom.xml
+++ b/pom.xml
@@ -393,6 +393,21 @@
           <groupId>org.codehaus.plexus</groupId>
           <artifactId>plexus-container-default</artifactId>
         </exclusion>
+        <exclusion>
+          <!-- not required and has known vulnerabilities -->
+          <groupId>org.apache.struts</groupId>
+          <artifactId>struts-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <!-- not required and no longer maintained -->
+          <groupId>org.apache.struts</groupId>
+          <artifactId>struts-taglib</artifactId>
+        </exclusion>
+        <exclusion>
+          <!-- not required and no longer maintained -->
+          <groupId>org.apache.struts</groupId>
+          <artifactId>struts-tiles</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>


### PR DESCRIPTION
Eliminates https://snyk.io/vuln/SNYK-JAVA-ORGAPACHESTRUTS-30763 warning.