### PR TITLE
Fixed documentation for check goal

### DIFF
--- a/src/site/apt/usage.apt.vm
+++ b/src/site/apt/usage.apt.vm
@@ -49,7 +49,7 @@ Usage
       <version>${project.version}</version>
       <executions>
         <execution>
-          <id>format-and-lint</id>
+          <id>format-and-check</id>
           <goals>
             <goal>format</goal>
             <goal>check</goal>
@@ -111,9 +111,9 @@ mvn ${project.groupId}:${project.artifactId}:${project.version}:format
       <version>${project.version}</version>
       <executions>
         <execution>
-          <id>lint</id>
+          <id>check</id>
           <goals>
-            <goal>lint</goal>
+            <goal>check</goal>
           </goals>
         </execution>
       </executions>
@@ -127,7 +127,7 @@ mvn ${project.groupId}:${project.artifactId}:${project.version}:format
   can run the following from your console:
 
 +----------+
-mvn ${project.groupId}:${project.artifactId}:${project.version}:lint
+mvn ${project.groupId}:${project.artifactId}:${project.version}:check
 +----------+
 
 * Generate ktlint report as part of the project reports


### PR DESCRIPTION
Was using previous name of `lint`.