### PR TITLE
Fixed JCenter repository name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1139,7 +1139,7 @@
         <enabled>false</enabled>
       </snapshots>
       <id>jcenter</id>
-      <name>bintray</name>
+      <name>JCenter</name>
       <url>http://jcenter.bintray.com</url>
     </repository>
   </repositories>


### PR DESCRIPTION
The name JCenter is more commonly used than Bintray.