### PR TITLE
Marked goals as thread-safe

### DIFF
--- a/src/main/kotlin/com/github/gantsign/maven/plugin/ktlint/CheckMojo.kt
+++ b/src/main/kotlin/com/github/gantsign/maven/plugin/ktlint/CheckMojo.kt
@@ -42,7 +42,8 @@ import java.nio.charset.StandardCharsets.UTF_8
     defaultPhase = LifecyclePhase.VERIFY,
     requiresDependencyResolution = ResolutionScope.TEST,
     requiresDependencyCollection = ResolutionScope.TEST,
-    requiresProject = true
+    requiresProject = true,
+    threadSafe = true
 )
 class CheckMojo : AbstractBaseMojo() {
 

--- a/src/main/kotlin/com/github/gantsign/maven/plugin/ktlint/FormatMojo.kt
+++ b/src/main/kotlin/com/github/gantsign/maven/plugin/ktlint/FormatMojo.kt
@@ -42,7 +42,8 @@ import java.nio.charset.StandardCharsets.UTF_8
     defaultPhase = LifecyclePhase.PROCESS_SOURCES,
     requiresDependencyResolution = ResolutionScope.TEST,
     requiresDependencyCollection = ResolutionScope.TEST,
-    requiresProject = true
+    requiresProject = true,
+    threadSafe = true
 )
 class FormatMojo : AbstractBaseMojo() {
 

--- a/src/main/kotlin/com/github/gantsign/maven/plugin/ktlint/KtlintReport.kt
+++ b/src/main/kotlin/com/github/gantsign/maven/plugin/ktlint/KtlintReport.kt
@@ -48,7 +48,8 @@ import java.util.ResourceBundle
     defaultPhase = LifecyclePhase.VERIFY,
     requiresDependencyResolution = ResolutionScope.TEST,
     requiresDependencyCollection = ResolutionScope.TEST,
-    requiresProject = true
+    requiresProject = true,
+    threadSafe = true
 )
 class KtlintReport : AbstractMavenReport() {
 


### PR DESCRIPTION
To remove the warning when executing parallel builds.

Enhancement: resolves #195