### PR TITLE
Suppressed missing directory warnings on POM modules

### DIFF
--- a/src/main/kotlin/com/github/gantsign/maven/plugin/ktlint/AbstractBaseMojo.kt
+++ b/src/main/kotlin/com/github/gantsign/maven/plugin/ktlint/AbstractBaseMojo.kt
@@ -34,6 +34,9 @@ abstract class AbstractBaseMojo : AbstractMojo() {
     @Parameter(defaultValue = "\${project.basedir}", readonly = true, required = true)
     protected lateinit var basedir: File
 
+    @Parameter(defaultValue = "\${project.packaging}", readonly = true, required = true)
+    protected lateinit var packaging: String
+
     @Parameter(defaultValue = "\${project.compileSourceRoots}", readonly = true, required = true)
     protected lateinit var sourceRoots: List<String>
 

--- a/src/main/kotlin/com/github/gantsign/maven/plugin/ktlint/CheckMojo.kt
+++ b/src/main/kotlin/com/github/gantsign/maven/plugin/ktlint/CheckMojo.kt
@@ -78,6 +78,7 @@ class CheckMojo : AbstractBaseMojo() {
         Check(
             log = log,
             basedir = basedir,
+            modulePackaging = packaging,
             sources = listOf(
                 Sources(
                     isIncluded = includeSources,

--- a/src/main/kotlin/com/github/gantsign/maven/plugin/ktlint/FormatMojo.kt
+++ b/src/main/kotlin/com/github/gantsign/maven/plugin/ktlint/FormatMojo.kt
@@ -60,6 +60,7 @@ class FormatMojo : AbstractBaseMojo() {
         Format(
             log = log,
             basedir = basedir,
+            modulePackaging = packaging,
             sources = listOf(
                 Sources(
                     isIncluded = includeSources,

--- a/src/main/kotlin/com/github/gantsign/maven/plugin/ktlint/KtlintReport.kt
+++ b/src/main/kotlin/com/github/gantsign/maven/plugin/ktlint/KtlintReport.kt
@@ -56,6 +56,9 @@ class KtlintReport : AbstractMavenReport() {
     @Parameter(defaultValue = "\${project.basedir}", readonly = true, required = true)
     private lateinit var basedir: File
 
+    @Parameter(defaultValue = "\${project.packaging}", readonly = true, required = true)
+    private lateinit var packaging: String
+
     @Parameter(defaultValue = "\${project.compileSourceRoots}", readonly = true, required = true)
     private lateinit var sourceRoots: List<String>
 
@@ -185,6 +188,7 @@ class KtlintReport : AbstractMavenReport() {
         val results = Report(
             log = log,
             basedir = basedir,
+            modulePackaging = packaging,
             sources = listOf(
                 Sources(
                     isIncluded = includeSources,

--- a/src/main/kotlin/com/github/gantsign/maven/plugin/ktlint/internal/AbstractCheckSupport.kt
+++ b/src/main/kotlin/com/github/gantsign/maven/plugin/ktlint/internal/AbstractCheckSupport.kt
@@ -45,6 +45,7 @@ import java.util.ServiceLoader
 internal abstract class AbstractCheckSupport(
     log: Log,
     basedir: File,
+    private val modulePackaging: String,
     private val sources: List<Sources>,
     private val charset: Charset,
     android: Boolean,
@@ -140,7 +141,12 @@ internal abstract class AbstractCheckSupport(
             }
             for (sourceRoot in sourceRoots) {
                 if (!sourceRoot.exists()) {
-                    log.warn("Source root doesn't exist: ${sourceRoot.toRelativeString(basedir)}")
+                    val msg = "Source root doesn't exist: ${sourceRoot.toRelativeString(basedir)}"
+                    if (modulePackaging == "pom") {
+                        log.debug(msg)
+                    } else {
+                        log.warn(msg)
+                    }
                     continue
                 }
                 if (!sourceRoot.isDirectory) {

--- a/src/main/kotlin/com/github/gantsign/maven/plugin/ktlint/internal/Check.kt
+++ b/src/main/kotlin/com/github/gantsign/maven/plugin/ktlint/internal/Check.kt
@@ -34,6 +34,7 @@ import java.nio.charset.Charset
 internal class Check(
     log: Log,
     basedir: File,
+    modulePackaging: String,
     sources: List<Sources>,
     charset: Charset,
     android: Boolean,
@@ -44,6 +45,7 @@ internal class Check(
 ) : AbstractCheckSupport(
     log,
     basedir,
+    modulePackaging,
     sources,
     charset,
     android,

--- a/src/main/kotlin/com/github/gantsign/maven/plugin/ktlint/internal/Format.kt
+++ b/src/main/kotlin/com/github/gantsign/maven/plugin/ktlint/internal/Format.kt
@@ -37,6 +37,7 @@ import java.nio.charset.Charset
 internal class Format(
     log: Log,
     basedir: File,
+    private val modulePackaging: String,
     private val sources: List<Sources>,
     private val charset: Charset,
     android: Boolean,
@@ -52,7 +53,12 @@ internal class Format(
             }
             for (sourceRoot in sourceRoots) {
                 if (!sourceRoot.exists()) {
-                    log.warn("Source root doesn't exist: ${sourceRoot.toRelativeString(basedir)}")
+                    val msg = "Source root doesn't exist: ${sourceRoot.toRelativeString(basedir)}"
+                    if (modulePackaging == "pom") {
+                        log.debug(msg)
+                    } else {
+                        log.warn(msg)
+                    }
                     continue
                 }
                 if (!sourceRoot.isDirectory) {

--- a/src/main/kotlin/com/github/gantsign/maven/plugin/ktlint/internal/Report.kt
+++ b/src/main/kotlin/com/github/gantsign/maven/plugin/ktlint/internal/Report.kt
@@ -34,6 +34,7 @@ import java.nio.charset.Charset
 internal class Report(
     log: Log,
     basedir: File,
+    modulePackaging: String,
     sources: List<Sources>,
     charset: Charset,
     android: Boolean,
@@ -43,6 +44,7 @@ internal class Report(
 ) : AbstractCheckSupport(
     log,
     basedir,
+    modulePackaging,
     sources,
     charset,
     android,


### PR DESCRIPTION
In general, missing source directorates in modules with `pom` packaging does not warrant a warning.

Enhancement: resolves #207