### PR TITLE
Fixed Maven Site plugin documentation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -672,6 +672,15 @@
     </plugins>
   </build>
 
+  <reporting>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-plugin-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </reporting>
+
   <url>https://github.com/gantsign/ktlint-maven-plugin</url>
 
   <inceptionYear>2018</inceptionYear>


### PR DESCRIPTION
Lost `maven-plugin-plugin` report plugin when project moved to use parent POM.

Fix resolves: #283