### PR TITLE
Removed sudo key from Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,6 @@
 # #L%
 ###
 ---
-sudo: false
-
 language: java
 
 jdk: openjdk8


### PR DESCRIPTION
The key `sudo` has no effect anymore.