### PR TITLE
Upgraded ktlint.version from 0.37.2 to 0.38.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
 
   <properties>
     <doxia.version>1.9.1</doxia.version>
-    <ktlint.version>0.37.2</ktlint.version>
+    <ktlint.version>0.38.1</ktlint.version>
     <license-maven-plugin.version>1.20</license-maven-plugin.version>
     <maven.version>3.5.4</maven.version>
     <mockk.version>1.9.3</mockk.version>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
   <parent>
     <groupId>com.github.gantsign.parent</groupId>
     <artifactId>kotlin-parent</artifactId>
-    <version>2.5.0</version>
+    <version>2.7.0</version>
     <relativePath />
   </parent>
 

--- a/src/test/kotlin/com/github/gantsign/maven/plugin/ktlint/FormatMojoTest.kt
+++ b/src/test/kotlin/com/github/gantsign/maven/plugin/ktlint/FormatMojoTest.kt
@@ -62,7 +62,7 @@ class FormatMojoTest {
         verify { log.debug("checking format: src/main/kotlin/example/Example.kt") }
         verify {
             log.debug(
-                "Format could not fix > src/main/kotlin/example/Example.kt:29:1: " +
+                "Format could not fix > src/main/kotlin/example/Example.kt:29:14: " +
                     "Exceeded max line length (80)"
             )
         }
@@ -92,7 +92,7 @@ class FormatMojoTest {
         verify { log.debug("checking format: src/main/kotlin/example/Example.kts") }
         verify {
             log.debug(
-                "Format could not fix > src/main/kotlin/example/Example.kts:29:1: " +
+                "Format could not fix > src/main/kotlin/example/Example.kts:29:14: " +
                     "Exceeded max line length (80)"
             )
         }


### PR DESCRIPTION
Bumps `ktlint.version` from 0.37.2 to 0.38.1.

Updates `ktlint` from 0.37.2 to 0.38.1
- [Release notes](https://github.com/pinterest/ktlint/releases)
- [Changelog](https://github.com/pinterest/ktlint/blob/master/CHANGELOG.md)
- [Commits](pinterest/ktlint@0.37.2...0.38.1)

Updates `ktlint-core` from 0.37.2 to 0.38.1
- [Release notes](https://github.com/pinterest/ktlint/releases)
- [Changelog](https://github.com/pinterest/ktlint/blob/master/CHANGELOG.md)
- [Commits](pinterest/ktlint@0.37.2...0.38.1)

Updates `ktlint-reporter-checkstyle` from 0.37.2 to 0.38.1
- [Release notes](https://github.com/pinterest/ktlint/releases)
- [Changelog](https://github.com/pinterest/ktlint/blob/master/CHANGELOG.md)
- [Commits](pinterest/ktlint@0.37.2...0.38.1)

Updates `ktlint-reporter-json` from 0.37.2 to 0.38.1
- [Release notes](https://github.com/pinterest/ktlint/releases)
- [Changelog](https://github.com/pinterest/ktlint/blob/master/CHANGELOG.md)
- [Commits](pinterest/ktlint@0.37.2...0.38.1)

Updates `ktlint-reporter-plain` from 0.37.2 to 0.38.1
- [Release notes](https://github.com/pinterest/ktlint/releases)
- [Changelog](https://github.com/pinterest/ktlint/blob/master/CHANGELOG.md)
- [Commits](pinterest/ktlint@0.37.2...0.38.1)

Updates `ktlint-ruleset-experimental` from 0.37.2 to 0.38.1
- [Release notes](https://github.com/pinterest/ktlint/releases)
- [Changelog](https://github.com/pinterest/ktlint/blob/master/CHANGELOG.md)
- [Commits](pinterest/ktlint@0.37.2...0.38.1)

Updates `ktlint-ruleset-standard` from 0.37.2 to 0.38.1
- [Release notes](https://github.com/pinterest/ktlint/releases)
- [Changelog](https://github.com/pinterest/ktlint/blob/master/CHANGELOG.md)
- [Commits](pinterest/ktlint@0.37.2...0.38.1)