### PR TITLE
Bump ktlint.version from 0.38.1 to 0.39.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
 
   <properties>
     <doxia.version>1.9.1</doxia.version>
-    <ktlint.version>0.38.1</ktlint.version>
+    <ktlint.version>0.39.0</ktlint.version>
     <license-maven-plugin.version>1.20</license-maven-plugin.version>
     <maven.version>3.5.4</maven.version>
     <mockk.version>1.9.3</mockk.version>

--- a/src/test/kotlin/com/github/gantsign/maven/plugin/ktlint/FormatMojoTest.kt
+++ b/src/test/kotlin/com/github/gantsign/maven/plugin/ktlint/FormatMojoTest.kt
@@ -62,7 +62,7 @@ class FormatMojoTest {
         verify { log.debug("checking format: src/main/kotlin/example/Example.kt") }
         verify {
             log.debug(
-                "Format could not fix > src/main/kotlin/example/Example.kt:29:14: " +
+                "Format could not fix > src/main/kotlin/example/Example.kt:29:1: " +
                     "Exceeded max line length (80)"
             )
         }
@@ -92,7 +92,7 @@ class FormatMojoTest {
         verify { log.debug("checking format: src/main/kotlin/example/Example.kts") }
         verify {
             log.debug(
-                "Format could not fix > src/main/kotlin/example/Example.kts:29:14: " +
+                "Format could not fix > src/main/kotlin/example/Example.kts:29:1: " +
                     "Exceeded max line length (80)"
             )
         }


### PR DESCRIPTION
Bumps `ktlint.version` from 0.38.1 to 0.39.0.

Updates `ktlint` from 0.38.1 to 0.39.0
- [Release notes](https://github.com/pinterest/ktlint/releases)
- [Changelog](https://github.com/pinterest/ktlint/blob/master/CHANGELOG.md)
- [Commits](https://github.com/pinterest/ktlint/compare/0.38.1...0.39.0)

Updates `ktlint-core` from 0.38.1 to 0.39.0
- [Release notes](https://github.com/pinterest/ktlint/releases)
- [Changelog](https://github.com/pinterest/ktlint/blob/master/CHANGELOG.md)
- [Commits](https://github.com/pinterest/ktlint/compare/0.38.1...0.39.0)

Updates `ktlint-reporter-checkstyle` from 0.38.1 to 0.39.0
- [Release notes](https://github.com/pinterest/ktlint/releases)
- [Changelog](https://github.com/pinterest/ktlint/blob/master/CHANGELOG.md)
- [Commits](https://github.com/pinterest/ktlint/compare/0.38.1...0.39.0)

Updates `ktlint-reporter-json` from 0.38.1 to 0.39.0
- [Release notes](https://github.com/pinterest/ktlint/releases)
- [Changelog](https://github.com/pinterest/ktlint/blob/master/CHANGELOG.md)
- [Commits](https://github.com/pinterest/ktlint/compare/0.38.1...0.39.0)

Updates `ktlint-reporter-plain` from 0.38.1 to 0.39.0
- [Release notes](https://github.com/pinterest/ktlint/releases)
- [Changelog](https://github.com/pinterest/ktlint/blob/master/CHANGELOG.md)
- [Commits](https://github.com/pinterest/ktlint/compare/0.38.1...0.39.0)

Updates `ktlint-ruleset-experimental` from 0.38.1 to 0.39.0
- [Release notes](https://github.com/pinterest/ktlint/releases)
- [Changelog](https://github.com/pinterest/ktlint/blob/master/CHANGELOG.md)
- [Commits](https://github.com/pinterest/ktlint/compare/0.38.1...0.39.0)

Updates `ktlint-ruleset-standard` from 0.38.1 to 0.39.0
- [Release notes](https://github.com/pinterest/ktlint/releases)
- [Changelog](https://github.com/pinterest/ktlint/blob/master/CHANGELOG.md)
- [Commits](https://github.com/pinterest/ktlint/compare/0.38.1...0.39.0)

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>