### PR TITLE
Upgraded ktlint.version from 0.43.2 to 0.44.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <guice.version>4.2.0</guice.version>
     <jacoco-maven-plugin.version>0.8.7</jacoco-maven-plugin.version>
     <kotlin.version>1.5.31</kotlin.version>
-    <ktlint.version>0.43.2</ktlint.version>
+    <ktlint.version>0.44.0</ktlint.version>
     <license-maven-plugin.version>1.20</license-maven-plugin.version>
     <maven.version>3.5.4</maven.version>
     <mockk.version>1.9.3</mockk.version>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <groupId>com.github.gantsign.parent</groupId>
     <artifactId>kotlin-parent</artifactId>
     <version>2.17.0</version>
-    <relativePath />
+    <relativePath/>
   </parent>
 
   <groupId>com.github.gantsign.maven</groupId>
@@ -51,7 +51,7 @@
     <doxia.version>1.11.1</doxia.version>
     <guice.version>4.2.0</guice.version>
     <jacoco-maven-plugin.version>0.8.7</jacoco-maven-plugin.version>
-    <kotlin.version>1.5.31</kotlin.version>
+    <kotlin.version>1.6.10</kotlin.version>
     <ktlint.version>0.44.0</ktlint.version>
     <license-maven-plugin.version>1.20</license-maven-plugin.version>
     <maven.version>3.5.4</maven.version>
@@ -286,6 +286,13 @@
     <dependency>
       <groupId>com.pinterest.ktlint</groupId>
       <artifactId>ktlint-core</artifactId>
+      <exclusions>
+        <exclusion>
+          <!-- Slf4j is natively supported by Maven -->
+          <groupId>ch.qos.logback</groupId>
+          <artifactId>logback-classic</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.pinterest.ktlint</groupId>
@@ -491,13 +498,13 @@
                   <version>[1.8,1.9)</version>
                 </requireJavaVersion>
                 <!-- When there are multiple versions of a dependency you have to choose which one to use. -->
-                <dependencyConvergence />
+                <dependencyConvergence/>
                 <requireReleaseDeps>
                   <message>No Snapshots Allowed!</message>
                   <onlyWhenRelease>true</onlyWhenRelease>
                 </requireReleaseDeps>
                 <!-- When there are multiple versions of a dependency you have to choose the maximum version. -->
-                <requireUpperBoundDeps />
+                <requireUpperBoundDeps/>
                 <requirePluginVersions>
                   <message>Best Practice is to always define plugin versions!</message>
                   <banLatest>true</banLatest>


### PR DESCRIPTION
Bumps `ktlint.version` from 0.43.2 to 0.44.0.

Updates `ktlint` from 0.43.2 to 0.44.0
- [Release notes](https://github.com/pinterest/ktlint/releases)
- [Changelog](https://github.com/pinterest/ktlint/blob/master/CHANGELOG.md)
- [Commits](https://github.com/pinterest/ktlint/compare/0.43.2...0.44.0)

Updates `ktlint-core` from 0.43.2 to 0.44.0
- [Release notes](https://github.com/pinterest/ktlint/releases)
- [Changelog](https://github.com/pinterest/ktlint/blob/master/CHANGELOG.md)
- [Commits](https://github.com/pinterest/ktlint/compare/0.43.2...0.44.0)

Updates `ktlint-reporter-checkstyle` from 0.43.2 to 0.44.0
- [Release notes](https://github.com/pinterest/ktlint/releases)
- [Changelog](https://github.com/pinterest/ktlint/blob/master/CHANGELOG.md)
- [Commits](https://github.com/pinterest/ktlint/compare/0.43.2...0.44.0)

Updates `ktlint-reporter-json` from 0.43.2 to 0.44.0
- [Release notes](https://github.com/pinterest/ktlint/releases)
- [Changelog](https://github.com/pinterest/ktlint/blob/master/CHANGELOG.md)
- [Commits](https://github.com/pinterest/ktlint/compare/0.43.2...0.44.0)

Updates `ktlint-reporter-plain` from 0.43.2 to 0.44.0
- [Release notes](https://github.com/pinterest/ktlint/releases)
- [Changelog](https://github.com/pinterest/ktlint/blob/master/CHANGELOG.md)
- [Commits](https://github.com/pinterest/ktlint/compare/0.43.2...0.44.0)

Updates `ktlint-ruleset-experimental` from 0.43.2 to 0.44.0
- [Release notes](https://github.com/pinterest/ktlint/releases)
- [Changelog](https://github.com/pinterest/ktlint/blob/master/CHANGELOG.md)
- [Commits](https://github.com/pinterest/ktlint/compare/0.43.2...0.44.0)

Updates `ktlint-ruleset-standard` from 0.43.2 to 0.44.0
- [Release notes](https://github.com/pinterest/ktlint/releases)
- [Changelog](https://github.com/pinterest/ktlint/blob/master/CHANGELOG.md)
- [Commits](https://github.com/pinterest/ktlint/compare/0.43.2...0.44.0)

---
updated-dependencies:
- dependency-name: com.pinterest:ktlint
  dependency-type: direct:production
  update-type: version-update:semver-minor
- dependency-name: com.pinterest.ktlint:ktlint-core
  dependency-type: direct:production
  update-type: version-update:semver-minor
- dependency-name: com.pinterest.ktlint:ktlint-reporter-checkstyle
  dependency-type: direct:production
  update-type: version-update:semver-minor
- dependency-name: com.pinterest.ktlint:ktlint-reporter-json
  dependency-type: direct:production
  update-type: version-update:semver-minor
- dependency-name: com.pinterest.ktlint:ktlint-reporter-plain
  dependency-type: direct:production
  update-type: version-update:semver-minor
- dependency-name: com.pinterest.ktlint:ktlint-ruleset-experimental
  dependency-type: direct:production
  update-type: version-update:semver-minor
- dependency-name: com.pinterest.ktlint:ktlint-ruleset-standard
  dependency-type: direct:production
  update-type: version-update:semver-minor
...