### PR TITLE
Optimized Github Actions cache for dependency updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,20 @@ jobs:
         with:
           java-version: 8
           distribution: 'temurin'
-          cache: 'maven'
+      # Since code changes to this project are infrequent, and most commits
+      # change the pom.xml, we cache by date interval rather than file hash.
+      - name: Calculate cache interval
+        run: |
+          leveler="$(wc -c <<< "$GITHUB_REPOSITORY")"
+          echo "::set-output name=CACHE_INTERVAL::$(date +%Y)-$(($(($leveler + $(date +%-j))) / 30))"
+        id: cache-interval
+      - name: Cache multiple paths
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.m2/repository
+            !~/.m2/repository/com/github/gantsign/maven
+          key: ${{ runner.os }}-maven-${{ steps.cache-interval.outputs.CACHE_INTERVAL }}
       - name: Build with Maven
         run: .github/scripts/build.sh
         env:
@@ -61,6 +74,20 @@ jobs:
         with:
           java-version: 8
           distribution: 'temurin'
+      # Since code changes to this project are infrequent, and most commits
+      # change the pom.xml, we cache by date interval rather than file hash.
+      - name: Calculate cache interval
+        run: |
+          leveler="$(wc -c <<< "$GITHUB_REPOSITORY")"
+          echo "::set-output name=CACHE_INTERVAL::$(date +%Y)-$(($(($leveler + $(date +%-j))) / 30))"
+        id: cache-interval
+      - name: Cache multiple paths
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.m2/repository
+            !~/.m2/repository/com/github/gantsign/maven
+          key: ${{ runner.os }}-maven-${{ steps.cache-interval.outputs.CACHE_INTERVAL }}
       - name: Install GPG key
         run: |-
           gpg --batch --import-options import-show --import << EOF

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,20 @@ jobs:
         with:
           java-version: 8
           distribution: 'temurin'
-          cache: 'maven'
+      # Since code changes to this project are infrequent, and most commits
+      # change the pom.xml, we cache by date interval rather than file hash.
+      - name: Calculate cache interval
+        run: |
+          leveler="$(wc -c <<< "$GITHUB_REPOSITORY")"
+          echo "::set-output name=CACHE_INTERVAL::$(date +%Y)-$(($(($leveler + $(date +%-j))) / 30))"
+        id: cache-interval
+      - name: Cache multiple paths
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.m2/repository
+            !~/.m2/repository/com/github/gantsign/maven
+          key: ${{ runner.os }}-maven-${{ steps.cache-interval.outputs.CACHE_INTERVAL }}
       - name: Build with Maven
         run: .github/scripts/build.sh
         env:
@@ -61,6 +74,20 @@ jobs:
         with:
           java-version: 8
           distribution: 'temurin'
+      # Since code changes to this project are infrequent, and most commits
+      # change the pom.xml, we cache by date interval rather than file hash.
+      - name: Calculate cache interval
+        run: |
+          leveler="$(wc -c <<< "$GITHUB_REPOSITORY")"
+          echo "::set-output name=CACHE_INTERVAL::$(date +%Y)-$(($(($leveler + $(date +%-j))) / 30))"
+        id: cache-interval
+      - name: Cache multiple paths
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.m2/repository
+            !~/.m2/repository/com/github/gantsign/maven
+          key: ${{ runner.os }}-maven-${{ steps.cache-interval.outputs.CACHE_INTERVAL }}
       - name: Install GPG key
         run: |-
           gpg --batch --import-options import-show --import << EOF
@@ -94,6 +121,20 @@ jobs:
         with:
           java-version: 8
           distribution: 'temurin'
+      # Since code changes to this project are infrequent, and most commits
+      # change the pom.xml, we cache by date interval rather than file hash.
+      - name: Calculate cache interval
+        run: |
+          leveler="$(wc -c <<< "$GITHUB_REPOSITORY")"
+          echo "::set-output name=CACHE_INTERVAL::$(date +%Y)-$(($(($leveler + $(date +%-j))) / 30))"
+        id: cache-interval
+      - name: Cache multiple paths
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.m2/repository
+            !~/.m2/repository/com/github/gantsign/maven
+          key: ${{ runner.os }}-maven-${{ steps.cache-interval.outputs.CACHE_INTERVAL }}
       - name: Configure Git user
         run: >-
           git config --global user.name 'John Freeman' &&

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -29,7 +29,20 @@ jobs:
         with:
           java-version: 8
           distribution: 'temurin'
-          cache: 'maven'
+      # Since code changes to this project are infrequent, and most commits
+      # change the pom.xml, we cache by date interval rather than file hash.
+      - name: Calculate cache interval
+        run: |
+          leveler="$(wc -c <<< "$GITHUB_REPOSITORY")"
+          echo "::set-output name=CACHE_INTERVAL::$(date +%Y)-$(($(($leveler + $(date +%-j))) / 30))"
+        id: cache-interval
+      - name: Cache multiple paths
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.m2/repository
+            !~/.m2/repository/com/github/gantsign/maven
+          key: ${{ runner.os }}-maven-${{ steps.cache-interval.outputs.CACHE_INTERVAL }}
       - name: Build with Maven
         run: .github/scripts/build.sh
         env:


### PR DESCRIPTION
Changed to cache by date interval rather than file hash. Most commits to this project are dependency updates, which results in a poor cache hit rate. Better that most of the dependencies are cached than none. Also, better to avoid updating the cache on every commit given most changes are only affect a single dependency.