### PR TITLE
Added .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# ktlint formatting changes
+5839307261f322b92cae8cd3e00cd5f6b3b4f133


### PR DESCRIPTION
To ignore recent formatting changes.