### PR TITLE
Upgrade Ktlint to 1.3.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,8 +53,8 @@
     <jacoco-maven-plugin.version>0.8.7</jacoco-maven-plugin.version>
     <java.require.version>11</java.require.version>
     <jdeps.multiRelease>11</jdeps.multiRelease>
-    <kotlin.version>1.9.22</kotlin.version>
-    <ktlint.version>1.2.1</ktlint.version>
+    <kotlin.version>1.9.24</kotlin.version>
+    <ktlint.version>1.3.1</ktlint.version>
     <license-maven-plugin.version>1.20</license-maven-plugin.version>
     <maven-plugin-plugin.version>3.6.4</maven-plugin-plugin.version>
     <maven.compiler.release>8</maven.compiler.release>

--- a/src/test/kotlin/com/github/gantsign/maven/plugin/ktlint/FormatMojoTest.kt
+++ b/src/test/kotlin/com/github/gantsign/maven/plugin/ktlint/FormatMojoTest.kt
@@ -64,16 +64,20 @@ class FormatMojoTest {
 
         verify(atLeast = 1) { log.isDebugEnabled }
         verify { log.debug("checking format: $source") }
-        verify { log.debug("Format fixed > $source:30:39: Unnecessary semicolon") }
+        verify { log.debug("Format fixed > $source:1:1: Unnecessary semicolon") }
         verify {
             log.debug(
-                "Format fixed > $source:29:13: Argument should be on a separate line " +
-                    "(unless all arguments can fit a single line)",
+                "Format fixed > $source:29:13: Line is exceeding max line length. Break line before expression",
             )
         }
-        verify { log.debug("Format fixed > $source:30:8: Missing newline before \")\"") }
-        verify { log.debug("Format fixed > $source:30:8: Missing trailing comma before \")\"") }
-        verify { log.debug("Format could not fix > $source:29:94: Exceeded max line length (80)") }
+        verify {
+            log.debug(
+                "Format fixed > $source:29:47: Line is exceeding max line length. Break line after '+' " +
+                    "in binary expression",
+            )
+        }
+        verify { log.debug("Format fixed > $source:30:19: Missing newline before \")\"") }
+        verify { log.debug("Format fixed > $source:30:20: Missing trailing comma before \")\"") }
         verify { log.debug("Format fixed > $source") }
         verify { log.warn("Source root doesn't exist: $testRoot") }
         verify { log.info("1 file(s) formatted.") }
@@ -98,15 +102,19 @@ class FormatMojoTest {
 
         verify(atLeast = 1) { log.isDebugEnabled }
         verify { log.debug("checking format: $scriptSource") }
-        verify { log.debug("Format fixed > $scriptSource:30:39: Unnecessary semicolon") }
+        verify { log.debug("Format fixed > $scriptSource:1:1: Unnecessary semicolon") }
         verify {
             log.debug(
-                "Format fixed > $scriptSource:29:13: Argument should be on a separate line " +
-                    "(unless all arguments can fit a single line)",
+                "Format fixed > $scriptSource:29:13: Line is exceeding max line length. Break line before expression",
             )
         }
-        verify { log.debug("Format fixed > $scriptSource:30:8: Missing newline before \")\"") }
-        verify { log.debug("Format could not fix > $scriptSource:29:94: Exceeded max line length (80)") }
+        verify {
+            log.debug(
+                "Format fixed > $scriptSource:29:47: Line is exceeding max line length. Break line after '+' " +
+                    "in binary expression",
+            )
+        }
+        verify { log.debug("Format fixed > $scriptSource:30:19: Missing newline before \")\"") }
         verify { log.debug("Format fixed > $scriptSource") }
         verify { log.warn("Source root doesn't exist: $testRoot") }
         verify { log.info("1 file(s) formatted.") }


### PR DESCRIPTION
Adresses #628
Ktlint 1.3.0 enabled a lot of previously experimental rules by default so this is a badly needed upgrade